### PR TITLE
feat: allow file reupload exploration

### DIFF
--- a/openassessment/workflow/models.py
+++ b/openassessment/workflow/models.py
@@ -72,6 +72,7 @@ class AssessmentWorkflow(TimeStampedModel, StatusModel):
         "waiting",
         "done",  # Complete
         "cancelled"  # User submission has been cancelled.
+        #"to_correct" # User submission has been market for re send
     ]
 
     STATUS_VALUES = STEPS + STATUSES


### PR DESCRIPTION
### Exploration: file reupload ora2 

Introduce a "to_correct" correction state in ORA Steps within Open edX

### Description:

This Pull Request aims to introduce a new state called "to_correct" for the ORA (Open Response Assessments) steps in Open edX. This state will allow instructors and students to revert to a previous step to make corrections, maintaining flexibility in the review and grading of assignments.

### Proposed Changes:

1.Introduction of a new "to_correct" state in the workflow, which triggers the ability to delete and edit previously uploaded files.
   
2.Update the submission_path_and_context method to handle this new state, selecting the appropriate template and context to render the page.

### Technical Details:

We have added an additional condition in the submission_path_and_context method to handle the new "to_correct" state. This condition changes the path value and updates the context to enable file deletion functionality.


```
...
        elif workflow["status"] == "to_correct":

            student_submission = self.get_user_submission(
                workflow["submission_uuid"]
            )
            peer_in_workflow = "peer" in workflow["status_details"]
            self_in_workflow = "self" in workflow["status_details"]
            context["peer_incomplete"] = peer_in_workflow and not workflow["status_details"]["peer"]["complete"]
            context["self_incomplete"] = self_in_workflow and not workflow["status_details"]["self"]["complete"]
            context["enable_delete_files"] = True
            context["student_submission"] = create_submission_dict(student_submission, self.prompts)
            path = 'openassessmentblock/response/oa_response.html'

...

```
