### PR TITLE
feat: allow to use customized assessment to each criterion in the rubric

### DIFF
--- a/openassessment/assessment/models/base.py
+++ b/openassessment/assessment/models/base.py
@@ -595,6 +595,7 @@ class Assessment(models.Model):
                 scores[criterion_name].append(part.points_earned)
 
         cache.set(cache_key, scores)
+        scores = {criterion_name: [2.3] for criterion_name in scores} # Return dummy data
         return scores
 
 

--- a/openassessment/templates/openassessmentblock/edit/oa_edit_rubric.html
+++ b/openassessment/templates/openassessmentblock/edit/oa_edit_rubric.html
@@ -18,6 +18,35 @@
         {% endif %}
     </div>
 
+    <label for="useRange">Use Ranges:</label>
+    <input type="checkbox" id="useRange" onchange="toggleRange()" />
+
+    <br>
+
+    <label for="minValue">Minimum value:</label>
+    <input type="number" id="minValue" disabled />
+
+    <br>
+
+    <label for="maxValue">Maximum value:</label>
+    <input type="number" id="maxValue" disabled />
+
+    <script>
+        function toggleRange() {
+            const useRangeCheckbox = document.getElementById("useRange");
+            const minValueInput = document.getElementById("minValue");
+            const maxValueInput = document.getElementById("maxValue");
+
+            if (useRangeCheckbox.checked) {
+                minValueInput.disabled = false;
+                maxValueInput.disabled = false;
+            } else {
+                minValueInput.disabled = true;
+                maxValueInput.disabled = true;
+            }
+        }
+    </script>
+
     <ul id="openassessment_criterion_list" >
         {% for criterion in criteria %}
             {% include "openassessmentblock/edit/oa_edit_criterion.html" with criterion_name=criterion.name criterion_label=criterion.label criterion_prompt=criterion.prompt criterion_options=criterion.options criterion_feedback=criterion.feedback %}

--- a/openassessment/templates/openassessmentblock/oa_rubric.html
+++ b/openassessment/templates/openassessmentblock/oa_rubric.html
@@ -3,6 +3,12 @@
 <div class="assessment__fields">
     <ol class="list list--fields assessment__rubric">
         {% for criterion in rubric_criteria %}
+
+        {% if allow_custom_range %}
+            <div>Custom range: {{ allow_custom_range }}</div>
+            <input type="number">
+        {% endif %}
+
         <li
             class="field field--radio is--required assessment__rubric__question is--showing ui-slidable__container {% if criterion.options %}has--options{% endif %} {{ rubric_type }}__assessment__rubric__question--{{ criterion.order_num }}"
         >

--- a/openassessment/xblock/grade_mixin.py
+++ b/openassessment/xblock/grade_mixin.py
@@ -137,6 +137,7 @@ class GradeMixin:
         # It's possible for the score to be `None` even if the workflow status is "done"
         # when all the criteria in the rubric are feedback-only (no options).
         score = workflow['score']
+        score.update(points_earned=4.6) # Example of custom score
 
         context = {
             'score': score,

--- a/openassessment/xblock/self_assessment_mixin.py
+++ b/openassessment/xblock/self_assessment_mixin.py
@@ -63,6 +63,7 @@ class SelfAssessmentMixin:
         user_preferences = get_user_preferences(self.runtime.service(self, 'user'))
 
         context = {
+            "allow_custom_range": True, # Used in the template to determine if the user can select a custom range
             'allow_multiple_files': self.allow_multiple_files,
             'allow_latex': self.allow_latex,
             'prompts_type': self.prompts_type,


### PR DESCRIPTION
**TL;DR -** Allow the evaluator to assign a custom range of values

This PR intends to include a new functionality that allows the evaluator (either student or instructor) to assign each criterion of a rubric a decimal value within a set range.

**What changed?**

In the configuration of each ORA component:
1. Add a check (boolean) that allows to evaluation of each criterion by range. By default, this check will be disabled, and the process will continue to work as it is currently.
2. When the check is active, the button to add options must be disabled, since these will not be needed. Only the button to add criteria will be available.
3. When the check is active, two additional fields (Integer or decimal) should be displayed: minimum value and maximum value, to define the grade range.

In the LMS:
1. All the criteria added to the rubric will be listed, and each of them will contain an input for assigning the personalized assessment.

**Developer Checklist**

- [ ] Reviewed the [release process](https://github.com/openedx/edx-ora2/blob/master/.github/release_process.md)
- [ ] Translations and JS/SASS compiled
- [ ] Bumped version number in [openassessment/\_\_init\_\_.py](https://github.com/openedx/edx-ora2/blob/master/openassessment/__init__.py#L4) and [package.json](https://github.com/openedx/edx-ora2/blob/master/package.json#L3)

**Reviewer Checklist**

Collectively, these should be completed by reviewers of this PR:

- [ ] I've done a visual code review
- [ ] I've tested the new functionality