### PR TITLE
Fg/featExploration ORA student reset assessment

### DIFF
--- a/openassessment/templates/openassessmentblock/edit/oa_edit_basic_settings_list.html
+++ b/openassessment/templates/openassessmentblock/edit/oa_edit_basic_settings_list.html
@@ -162,4 +162,17 @@
             {% trans "Specify whether learners can see the rubric while they are working on their response." %}
         </p>
     </li>
+    <!-- Creating a learner max modify time -->
+    <li id="openassessment_modify_time_wrapper" class="field comp-setting-entry">
+        <div class="wrapper-comp-setting">
+            <label for="openassessment_modify_time" class="setting-label">{% trans "Assessment Retry Max Time" %}</label>
+            
+            <label for="openassessment_retry_hours" style="margin-right: 10px;">{% trans "Hours" %}</label>
+            <input type="number" id="openassessment_retry_hours" class="input setting-input" min="0" value="{{ openassessment_retry_hours }}" style="width: 50px; max-width: 50px;">
+            
+            <label for="openassessment_retry_minutes" style="margin-left: 20px; margin-right: 10px;">{% trans "Minutes" %}</label>
+            <input type="number" id="openassessment_retry_minutes" class="input setting-input" min="0" max="59" value="{{ openassessment_retry_minutes }}" style="width: 50px; max-width: 50px;">
+        </div>
+        <p class="setting-help">{% trans "Max time to retry an assessment." %}</p>
+    </li>
 </ul>

--- a/openassessment/templates/openassessmentblock/peer/oa_peer_waiting.html
+++ b/openassessment/templates/openassessmentblock/peer/oa_peer_waiting.html
@@ -38,5 +38,16 @@
             </div>
         </div>
     </div>
+    {% if retry_assessment_enable %}
+      <button 
+      class="peer-waiting--001__assessment__retry_assessment_button" 
+      style="background: rgb(0,117,180); color: white; padding: 10px 20px; border-radius: 5px; cursor: pointer; border: none;"
+      data-userid="{{user_id}}">
+          Reset your submission to be able to send it again
+      </button>
+    {% else %}
+
+    {% endif %}
+
 </div>
 {% endblock %}

--- a/openassessment/templates/openassessmentblock/self/oa_self_assessment.html
+++ b/openassessment/templates/openassessmentblock/self/oa_self_assessment.html
@@ -24,7 +24,6 @@
                 </span>
             </h4>
         </span>
-
        {% if self_start %}
        <span class="step__deadline">
            {# Translators: This string displays a date to the user, then tells them the time until that date.  Example: "available August 13th, 2014 (in 5 days and 45 minutes)" #}
@@ -77,6 +76,17 @@
                         <button type="submit" class="self-assessment--001__assessment__submit action action--submit" disabled>
                             {% trans "Submit your assessment" %}
                         </button>
+
+                        {% if retry_assessment_enable %}
+                            <button 
+                            class="self-assessment--001__assessment__retry_assessment_button" 
+                            style="background: rgb(0,117,180); color: white; padding: 10px 20px; border-radius: 5px; cursor: pointer; border: none;"
+                            data-userid="{{user_id}}">
+                                Reset your submission to be able to send it again
+                            </button>
+                        {% else %}
+
+                        {% endif %}
                     </li>
                 </ul>
             </div>

--- a/openassessment/templates/openassessmentblock/staff/oa_staff_grade.html
+++ b/openassessment/templates/openassessmentblock/staff/oa_staff_grade.html
@@ -35,6 +35,16 @@
                 </div>
             </div>
         </div>
+        {% if retry_assessment_enable %}
+            <button 
+            class="staff-waiting--001__assessment__retry_assessment_button" 
+            style="background: rgb(0,117,180); color: white; padding: 10px 20px; border-radius: 5px; cursor: pointer; border: none;"
+            data-userid="{{user_id}}">
+                Reset your submission to be able to send it again
+            </button>
+        {% else %}
+
+        {% endif %}
     </div>
     {% endif %}
 

--- a/openassessment/templates/openassessmentblock/student_training/student_training.html
+++ b/openassessment/templates/openassessmentblock/student_training/student_training.html
@@ -150,6 +150,16 @@
                         <button type="submit" class="student-training--001__assessment__submit action action--submit" disabled>
                             {% trans "Compare your selections with the instructor's selections" %}
                         </button>
+                        {% if retry_assessment_enable %}
+                            <button 
+                            class="student-training--001__assessment__retry_assessment_button" 
+                            style="background: rgb(0,117,180); color: white; padding: 10px 20px; border-radius: 5px; cursor: pointer; border: none;"
+                            data-userid="{{user_id}}">
+                                Reset your submission to be able to send it again
+                            </button>
+                        {% else %}
+
+                        {% endif %}
                     </li>
                 </ul>
             </div>

--- a/openassessment/xblock/apis/ora_config_api.py
+++ b/openassessment/xblock/apis/ora_config_api.py
@@ -14,6 +14,8 @@ class ORAConfigAPI:
         "file_upload_type_raw",
         "has_saved",
         "leaderboard_show",
+        "openassessment_retry_minutes",
+        "openassessment_retry_hours",
         "prompt",
         "prompts_type",
         "rubric_criteria",

--- a/openassessment/xblock/openassessmentblock.py
+++ b/openassessment/xblock/openassessmentblock.py
@@ -12,6 +12,7 @@ import pytz
 
 from django.conf import settings
 from django.template.loader import get_template
+from django.contrib.auth import get_user_model
 
 from bleach.sanitizer import Cleaner
 from lazy import lazy
@@ -57,7 +58,6 @@ from openassessment.xblock.team_workflow_mixin import TeamWorkflowMixin
 from openassessment.xblock.openassesment_template_mixin import OpenAssessmentTemplatesMixin
 from openassessment.xblock.utils.xml import parse_from_xml, serialize_content_to_xml
 
-
 from openassessment.xblock.apis.ora_config_api import ORAConfigAPI
 from openassessment.xblock.apis.workflow_api import WorkflowAPI
 from openassessment.xblock.apis.assessments.peer_assessment_api import PeerAssessmentAPI
@@ -65,6 +65,7 @@ from openassessment.xblock.apis.assessments.self_assessment_api import SelfAsses
 from openassessment.xblock.apis.assessments.staff_assessment_api import StaffAssessmentAPI
 from openassessment.xblock.apis.assessments.student_training_api import StudentTrainingAPI
 from openassessment.xblock.apis.ora_data_accessor import ORADataAccessor
+from lms.djangoapps.instructor.enrollment import reset_student_attempts
 
 logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
 
@@ -162,6 +163,18 @@ class OpenAssessmentBlock(
         default=0,
         scope=Scope.content,
         help="The number of leaderboard results to display (0 if none)"
+    )
+
+    openassessment_retry_minutes = Integer(
+        default=0,
+        scope=Scope.content,
+        help="The number of minutes to retry the submission"
+    )
+
+    openassessment_retry_hours= Integer(
+        default=0,
+        scope=Scope.content,
+        help="The number of hours to retry the submission"
     )
 
     no_peers = Boolean(
@@ -811,6 +824,8 @@ class OpenAssessmentBlock(
         block.file_upload_type = config['file_upload_type']
         block.group_access = config['group_access']
         block.leaderboard_show = config['leaderboard_show']
+        block.openassessment_retry_minutes = config['openassessment_retry_minutes']
+        block.openassessment_retry_hours = config['openassessment_retry_hours']
         block.prompts = config['prompts']
         block.prompts_type = config['prompts_type']
         block.rubric_criteria = config['rubric_criteria']
@@ -1234,6 +1249,24 @@ class OpenAssessmentBlock(
 
         self.runtime.publish(self, event_name, data)
         return {'success': True}
+
+
+    @XBlock.json_handler
+    def reset_student_assessment(self, data, suffix=''):  # pylint: disable=unused-argument
+        """
+        Reset the assessment attempts for a given student.
+
+        Args:
+            data (dict): Contains the student information, e.g. { "user_id": "12345" }
+            suffix (str, optional): Unused parameter. Defaults to ''.
+
+        Returns:
+            dict: A dictionary indicating the success status, e.g. { 'success': True }
+        """
+        user = get_user_model().objects.get(id= data["user_id"])
+        reset_student_attempts(self.course_id, user, self.location, user, True)
+        return {'success': True}
+
 
     def get_real_user(self, anonymous_user_id):
         """

--- a/openassessment/xblock/static/js/src/lms/oa_peer.js
+++ b/openassessment/xblock/static/js/src/lms/oa_peer.js
@@ -174,6 +174,36 @@ export class PeerView {
         },
       );
 
+      // Install a click handler for the reset button
+      sel.find('.peer-waiting--001__assessment__retry_assessment_button').click(
+        (eventObject) => {
+          // Override default form submission
+          eventObject.preventDefault();
+
+          // Confirm dialog
+          let isConfirmed = window.confirm("This will reset your assessment, are you sure?");
+
+          // If user confirms (clicks "OK"), then continue with the rest of the logic
+          if (isConfirmed) {
+              // Obtain the values from the button's data attributes and store in an object
+              let values = {
+                userid: $(eventObject.target).data('userid'),
+              };
+
+              // Handle the click and send the object to your function
+              view.selfReset(values);
+
+              // Refreshing window
+              window.location.reload(true);
+              
+          } else {
+              // Optional: Handle the case where the user clicked "Cancel"
+              console.log("Reset Cancelled.");
+          }
+        },
+      );
+
+
       // Install a click handler for continued assessment
       sel.find('.action--continue--grading').click(
         (eventObject) => {
@@ -181,6 +211,15 @@ export class PeerView {
           view.loadContinuedAssessment(view.baseView.getUsageID());
         },
       );
+    }
+
+    // Call to server Student reset assessment fuction
+    selfReset(data){
+      const view = this;
+      const { baseView } = this;
+      const usageID = baseView.getUsageID();
+  
+      this.server.resetStudentAssessment(data);
     }
 
     /**

--- a/openassessment/xblock/static/js/src/lms/oa_self.js
+++ b/openassessment/xblock/static/js/src/lms/oa_self.js
@@ -102,6 +102,45 @@ export class SelfView {
           view.selfAssess();
         },
       );
+
+      // Install a click handler for the reset button
+      sel.find('.self-assessment--001__assessment__retry_assessment_button').click(
+        (eventObject) => {
+          // Override default form submission
+          eventObject.preventDefault();
+
+          // Confirm dialog
+          let isConfirmed = window.confirm("This will reset your assessment, are you sure?");
+
+          // If user confirms (clicks "OK"), then continue with the rest of the logic
+          if (isConfirmed) {
+              // Obtain the values from the button's data attributes and store in an object
+              let values = {
+                userid: $(eventObject.target).data('userid'),
+              };
+
+              // Handle the click and send the object to your function
+              view.selfReset(values);
+
+              // Refreshing window
+              window.location.reload(true);
+              
+          } else {
+              // Optional: Handle the case where the user clicked "Cancel"
+              console.log("Reset Cancelled.");
+          }
+        },
+      );
+
+    }
+
+    // Call to server Student reset assessment fuction
+    selfReset(data){
+      const view = this;
+      const { baseView } = this;
+      const usageID = baseView.getUsageID();
+
+      this.server.resetStudentAssessment(data);
     }
 
     /**

--- a/openassessment/xblock/static/js/src/lms/oa_staff.js
+++ b/openassessment/xblock/static/js/src/lms/oa_staff.js
@@ -40,8 +40,48 @@ export class StaffView {
     * */
   installHandlers() {
     // Install a click handler for collapse/expand
+    const view = this;
     this.baseView.setUpCollapseExpand($('.step--staff-assessment', this.element));
+
+    // Install a click handler for the reset button
+    $('.step--staff-assessment', this.element).find('.staff-waiting--001__assessment__retry_assessment_button').click(
+      (eventObject) => {
+        // Override default form submission
+        eventObject.preventDefault();
+
+        // Confirm dialog
+        let isConfirmed = window.confirm("This will reset your assessment, are you sure?");
+
+        // If user confirms (clicks "OK"), then continue with the rest of the logic
+        if (isConfirmed) {
+            // Obtain the values from the button's data attributes and store in an object
+            let values = {
+              userid: $(eventObject.target).data('userid'),
+            };
+
+            // Handle the click and send the object to your function
+            view.selfReset(values);
+
+            // Refreshing window
+            window.location.reload(true);
+            
+        } else {
+            // Optional: Handle the case where the user clicked "Cancel"
+            console.log("Reset Cancelled.");
+        }
+      },
+    );
   }
+
+  // Call to server Student reset assessment fuction
+  selfReset(data){
+    const view = this;
+    const { baseView } = this;
+    const usageID = baseView.getUsageID();
+
+    this.server.resetStudentAssessment(data);
+  }
+
 }
 
 export default StaffView;

--- a/openassessment/xblock/static/js/src/lms/oa_training.js
+++ b/openassessment/xblock/static/js/src/lms/oa_training.js
@@ -66,6 +66,7 @@ export class StudentTrainingView {
     Install event handlers for the view.
     * */
   installHandlers() {
+    const view = this
     const sel = $('.step--student-training', this.element);
 
     // Install a click handler for collapse/expand
@@ -94,6 +95,43 @@ export class StudentTrainingView {
         this.announceStatus = true;
       },
     );
+  
+      // Install a click handler for the reset button
+      sel.find('.student-training--001__assessment__retry_assessment_button').click(
+        (eventObject) => {
+          // Override default form submission
+          eventObject.preventDefault();
+
+          // Confirm dialog
+          let isConfirmed = window.confirm("This will reset your assessment, are you sure?");
+
+          // If user confirms (clicks "OK"), then continue with the rest of the logic
+          if (isConfirmed) {
+              // Obtain the values from the button's data attributes and store in an object
+              let values = {
+                userid: $(eventObject.target).data('userid'),
+              };
+
+              // Handle the click and send the object to your function
+              view.selfReset(values);
+
+              // Refreshing window
+              window.location.reload(true);
+              
+          } else {
+              // Optional: Handle the case where the user clicked "Cancel"
+              console.log("Reset Cancelled.");
+          }
+        },
+      );
+  }
+
+  // Call to server Student reset assessment fuction
+  selfReset(data){
+    const view = this;
+    const { baseView } = this;
+    const usageID = baseView.getUsageID();
+    this.server.resetStudentAssessment(data);
   }
 
   /**

--- a/openassessment/xblock/static/js/src/oa_server.js
+++ b/openassessment/xblock/static/js/src/oa_server.js
@@ -31,6 +31,7 @@ export class Server {
     this.selfAssess = this.selfAssess.bind(this);
     this.staffAssess = this.staffAssess.bind(this);
     this.trainingAssess = this.trainingAssess.bind(this);
+    this.resetStudentAssessment = this.resetStudentAssessment.bind(this);
     this.scheduleTraining = this.scheduleTraining.bind(this);
     this.rescheduleUnfinishedTasks = this.rescheduleUnfinishedTasks.bind(this);
     this.updateEditorContext = this.updateEditorContext.bind(this);
@@ -380,6 +381,31 @@ export class Server {
     });
   }
 
+    /**
+   * Reset a student's assessment.
+   *
+   * @param {object} values_obj - Contains the student information, 
+   *     e.g. { userid: "12345" }
+   * @returns {promise} A promise which logs "Success" if successful,
+   *     and "Error" otherwise.
+   */
+  resetStudentAssessment(values_obj) {
+    const url = this.url('reset_student_assessment');
+    const payload = JSON.stringify({
+      user_id: values_obj.userid,
+    });
+    return $.Deferred((defer) => {
+      $.ajax({
+        type: 'POST', url, data: payload, contentType: jsonContentType,
+      }).done(function (data) {
+        console.log("Success");
+      }).fail(function () {
+        console.log("Error");
+      });
+    });
+  }
+
+
   /**
    * Schedules classifier training for Example Based Assessments.
    *
@@ -471,6 +497,8 @@ export class Server {
       allow_multiple_files: options.multipleFilesEnabled,
       allow_latex: options.latexEnabled,
       leaderboard_show: options.leaderboardNum,
+      openassessment_retry_minutes: options.retryAssessmentMinsNum,
+      openassessment_retry_hours: options.retryAssessmentHoursNum,
       teams_enabled: options.teamsEnabled,
       selected_teamset_id: options.selectedTeamsetId,
       show_rubric_during_response: options.showRubricDuringResponse,

--- a/openassessment/xblock/static/js/src/studio/oa_edit.js
+++ b/openassessment/xblock/static/js/src/studio/oa_edit.js
@@ -250,6 +250,8 @@ export class StudioView {
       multipleFilesEnabled: teamsEnabled ? true : this.settingsView.multipleFilesEnabled(),
       latexEnabled: this.settingsView.latexEnabled(),
       leaderboardNum: this.settingsView.leaderboardNum(),
+      retryAssessmentMinsNum:this.settingsView.retryAssessmentMinsNum(),
+      retryAssessmentHoursNum:this.settingsView.retryAssessmentHoursNum(),
       editorAssessmentsOrder: this.assessmentsStepsView.editorAssessmentsOrder(),
       teamsEnabled,
       selectedTeamsetId: this.settingsView.teamset(),

--- a/openassessment/xblock/static/js/src/studio/oa_edit_settings.js
+++ b/openassessment/xblock/static/js/src/studio/oa_edit_settings.js
@@ -42,6 +42,9 @@ export class EditSettingsView {
     this.setHidden = this.setHidden.bind(this);
     this.teamset = this.teamset.bind(this);
     this.leaderboardNum = this.leaderboardNum.bind(this);
+    this.retryAssessmentMinsNum = this.retryAssessmentMinsNum.bind(this);
+    this.retryAssessmentHoursNum = this.retryAssessmentHoursNum.bind(this);
+
     this.validate = this.validate.bind(this);
     this.validationErrors = this.validationErrors.bind(this);
     this.clearValidationErrors = this.clearValidationErrors.bind(this);
@@ -81,6 +84,15 @@ export class EditSettingsView {
       $('#openassessment_leaderboard_editor', this.element),
       { min: 0, max: 100 },
     );
+
+    this.retryAssessmentMinsIntField = new IntField(
+      $('#openassessment_retry_minutes', this.element),
+      { min: 0, max: 59 },
+    );
+    this.retryAssessmentHoursIntField = new IntField(
+      $('#openassessment_retry_hours', this.element),
+      { min: 0 },
+    );    
 
     this.fileTypeWhiteListInputField = new InputControl(
       $('#openassessment_submission_white_listed_file_types', this.element),
@@ -430,6 +442,20 @@ export class EditSettingsView {
     }
     return this.leaderboardIntField.get(num);
   }
+
+  retryAssessmentMinsNum(num) {
+    if (num !== undefined) {
+      this.retryAssessmentMinsIntField.set(num);
+    }
+    return this.retryAssessmentMinsIntField.get(num);
+  }
+  retryAssessmentHoursNum(num) {
+    if (num !== undefined) {
+      this.retryAssessmentHoursIntField.set(num);
+    }
+    return this.retryAssessmentHoursIntField.get(num);
+  }
+
 
   /**
     Enable / disable showing learners the assessment rubric while working on their response.

--- a/openassessment/xblock/studio_mixin.py
+++ b/openassessment/xblock/studio_mixin.py
@@ -194,6 +194,8 @@ class StudioMixin:
             'white_listed_file_types': white_listed_file_types_string,
             'allow_latex': self.allow_latex,
             'leaderboard_show': self.leaderboard_show,
+            'openassessment_retry_minutes': self.openassessment_retry_minutes,
+            'openassessment_retry_hours': self.openassessment_retry_hours,
             'editor_assessments_order': [
                 make_django_template_key(asmnt)
                 for asmnt in self.editor_assessments_order
@@ -315,6 +317,8 @@ class StudioMixin:
         self.allow_multiple_files = bool(data['allow_multiple_files'])
         self.allow_latex = bool(data['allow_latex'])
         self.leaderboard_show = data['leaderboard_show']
+        self.openassessment_retry_minutes = data['openassessment_retry_minutes']
+        self.openassessment_retry_hours = data['openassessment_retry_hours']
         self.teams_enabled = bool(data.get('teams_enabled', False))
         self.selected_teamset_id = data.get('selected_teamset_id', '')
         self.show_rubric_during_response = data.get('show_rubric_during_response', False)

--- a/openassessment/xblock/ui_mixins/legacy/peer_assessments/views.py
+++ b/openassessment/xblock/ui_mixins/legacy/peer_assessments/views.py
@@ -5,6 +5,7 @@ from webob import Response
 from openassessment.xblock.utils.defaults import DEFAULT_RUBRIC_FEEDBACK_TEXT
 
 from openassessment.xblock.utils.user_data import get_user_preferences
+from openassessment.xblock.utils.retry_assessment import retry_assessment_enable
 
 
 template_paths = {
@@ -19,8 +20,10 @@ template_paths = {
 }
 
 
-def peer_context(config_data, step_data, peer_sub=None):
+def peer_context(api_data, step_data, peer_sub=None):
+    config_data = api_data.config_data
     user_preferences = get_user_preferences(config_data.user_service)
+    retry_enable = retry_assessment_enable(api_data)
     context_dict = {
         "rubric_criteria": config_data.rubric_criteria_with_labels,
         "allow_multiple_files": config_data.allow_multiple_files,
@@ -29,6 +32,8 @@ def peer_context(config_data, step_data, peer_sub=None):
         "user_timezone": user_preferences["user_timezone"],
         "user_language": user_preferences["user_language"],
         "xblock_id": config_data.get_xblock_id(),
+        "retry_assessment_enable": retry_enable,
+        "user_id" : api_data._block.scope_ids.user_id,
     }
 
     if config_data.rubric_feedback_prompt is not None:
@@ -98,7 +103,7 @@ def peer_path_and_context(api_data, continue_grading):
     def path_and_context(path_key, peer_sub=None):
         return (
             template_paths[path_key],
-            peer_context(api_data.config_data, step_data, peer_sub),
+            peer_context(api_data, step_data, peer_sub),
         )
 
     if step_data.is_cancelled:

--- a/openassessment/xblock/ui_mixins/legacy/self_assessments/views.py
+++ b/openassessment/xblock/ui_mixins/legacy/self_assessments/views.py
@@ -5,6 +5,7 @@ import logging
 from webob import Response
 
 from openassessment.xblock.utils.user_data import get_user_preferences
+from openassessment.xblock.utils.retry_assessment import retry_assessment_enable
 
 logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
 
@@ -36,6 +37,7 @@ def render_self_assessment(api_data):
 def self_context(api_data, with_sub=False):
     config_data = api_data.config_data
     user_preferences = get_user_preferences(config_data.user_service)
+    retry_enable = retry_assessment_enable(api_data)
     context = {
         "allow_multiple_files": config_data.allow_multiple_files,
         "allow_latex": config_data.allow_latex,
@@ -43,6 +45,8 @@ def self_context(api_data, with_sub=False):
         "xblock_id": config_data.get_xblock_id(),
         "user_timezone": user_preferences["user_timezone"],
         "user_language": user_preferences["user_language"],
+        "retry_assessment_enable": retry_enable,
+        "user_id" : api_data._block.scope_ids.user_id,
     }
 
     step_data = api_data.self_assessment_data

--- a/openassessment/xblock/ui_mixins/legacy/staff_assessments/views.py
+++ b/openassessment/xblock/ui_mixins/legacy/staff_assessments/views.py
@@ -7,6 +7,7 @@ import logging
 from openassessment.assessment.api import (
     staff as staff_api,
 )
+from openassessment.xblock.utils.retry_assessment import retry_assessment_enable
 
 logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
 
@@ -42,6 +43,7 @@ def staff_context(api_data):
     """
     step_data = api_data.staff_assessment_data
     translate = api_data.config_data.translate
+    retry_enable = retry_assessment_enable(api_data)
 
     not_available_context = {
         "status_value": translate("Not Available"),
@@ -77,6 +79,8 @@ def staff_context(api_data):
             ),
             "step_classes": "is--showing",
             "button_active": "aria-expanded=true",
+            "retry_assessment_enable": retry_enable, 
+            "user_id" : api_data._block.scope_ids.user_id,
         }
     elif not step_data.has_status:
         context = not_available_context

--- a/openassessment/xblock/ui_mixins/legacy/student_training/views.py
+++ b/openassessment/xblock/ui_mixins/legacy/student_training/views.py
@@ -4,6 +4,7 @@ Student training step in the OpenAssessment XBlock.
 import logging
 
 from webob import Response
+from openassessment.xblock.utils.retry_assessment import retry_assessment_enable
 
 
 logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
@@ -60,7 +61,8 @@ def training_context(api_data):
     # Retrieve the status of the workflow.
     # If no submissions have been created yet, the status will be None.
     user_preferences = api_data.config_data.user_preferences
-
+    retry_enable = retry_assessment_enable(api_data)
+    
     context = {
         "xblock_id": config_data.get_xblock_id(),
         "allow_multiple_files": config_data.allow_multiple_files,
@@ -68,6 +70,8 @@ def training_context(api_data):
         "prompts_type": config_data.prompts_type,
         "user_timezone": user_preferences["user_timezone"],
         "user_language": user_preferences["user_language"],
+        "retry_assessment_enable": retry_enable,
+        "user_id" : api_data._block.scope_ids.user_id,
     }
 
     if not step_data.has_workflow:

--- a/openassessment/xblock/utils/retry_assessment.py
+++ b/openassessment/xblock/utils/retry_assessment.py
@@ -1,0 +1,95 @@
+from datetime import datetime, timedelta
+import pytz
+from openassessment.management.commands.create_oa_submissions_from_file import Command
+from django.http import HttpResponse
+
+
+def assessment_retry_max_time(api_data):
+    """
+    This function takes an api_data object, extracts num_hour, num_min, and submission_datetime from it,
+    converts num_hour and num_min to seconds to create a timedelta, which is then added to submission_datetime.
+    If the resulting datetime is greater than the current datetime, the function returns True, otherwise, it returns False.
+    
+    :param api_data (object): The object containing necessary data, including config_data and submission_data.
+    :return: bool: True if the resulting datetime is in the future, False if it is in the past or present
+    
+    """
+    config_data = api_data.config_data
+    submission_data = api_data.submission_data
+
+    #submission_data.editor_assessments_order
+
+    # Disable retry option if current datetime it is higher than ora due datetime
+    try:
+        ora_due_date = datetime.strptime(config_data.submission_due, "%Y-%m-%dT%H:%M:%S%z")
+    except:
+        ora_due_date = datetime.strptime(config_data.submission_due, "%Y-%m-%dT%H:%M")
+
+    current_datetime = datetime.now(pytz.UTC)
+    ora_due_date = ora_due_date.replace(tzinfo=pytz.UTC)
+    if current_datetime >= ora_due_date:
+        return False
+
+    # Enable retry option if the retry period is higher than current datetime
+    num_hour = config_data.openassessment_retry_hours 
+    num_min = config_data.openassessment_retry_minutes
+    try:
+        student_submission_datetime = submission_data.student_submission['created_at']
+        if student_submission_datetime.tzinfo is None:
+            student_submission_datetime = student_submission_datetime.replace(tzinfo=pytz.UTC)
+    except:
+        return False
+
+    delta_time = timedelta(hours=int(num_hour), minutes=int(num_min))
+    retry_period = student_submission_datetime + delta_time
+    
+    return retry_period > current_datetime
+
+
+def workflow_status_handler(api_data):
+    """
+    Determines the workflow status of a student's response based on whether it 
+    has been graded by peers, staff, or not at all.
+    
+    :param: api_data (object): Contains workflow data including status details.
+    :return: bool: True if the student's response hasn't been graded by peers or staff, 
+          False otherwise.
+    """
+    workflow_data = api_data.workflow_data
+    status_details = workflow_data.status_details
+    training_guard, self_guard, peer_guard, staff_guard = True, True, True, True
+
+    # Check if the student has not graded or been graded by another 
+    if workflow_data.has_status:
+        if 'peer' in workflow_data.status_details:
+            if status_details['peer']['peers_graded_count'] != 0 or \
+                status_details['peer']['graded_by_count'] != None:
+                if status_details['peer']['graded_by_count'] == 0:
+                    pass
+                else:
+                    peer_guard = False
+
+        # Check if the staff has not graded the student
+        if workflow_data.status == "done":
+            staff_guard = False
+    else:
+        return False
+
+    return (self_guard and peer_guard and staff_guard and training_guard)
+
+
+def retry_assessment_enable(api_data):
+    """
+    Determines if a student's assessment can be retried based on time and workflow status criteria.
+
+    This function combines the results of both the assessment_retry_max_time and workflow_status_handler functions
+    to decide if a student's assessment can be retried. The assessment is eligible for retry if the allowed retry
+    period is still valid (not expired) and the assessment has not been graded by either peers or staff.
+
+    :param api_data (object): The object containing necessary data for time and workflow status checks.
+    :return: bool: True if the student's assessment is eligible for retry, False otherwise.
+    """
+    time_handler = assessment_retry_max_time(api_data)
+    workflow_handler = workflow_status_handler(api_data)
+
+    return (time_handler and workflow_handler)

--- a/openassessment/xblock/utils/schema.py
+++ b/openassessment/xblock/utils/schema.py
@@ -124,6 +124,8 @@ EDITOR_UPDATE_SCHEMA = Schema({
     Required('allow_multiple_files'): bool,
     Required('allow_latex'): bool,
     Required('leaderboard_show'): int,
+    Required('openassessment_retry_minutes'): int,
+    Required('openassessment_retry_hours'): int,
     Optional('teams_enabled'): bool,
     Optional('selected_teamset_id'): utf8_validator,
     Required('assessments'): [

--- a/openassessment/xblock/utils/xml.py
+++ b/openassessment/xblock/utils/xml.py
@@ -715,6 +715,14 @@ def serialize_content_to_xml(oa_block, root):
     if oa_block.leaderboard_show:
         root.set('leaderboard_show', str(oa_block.leaderboard_show))
 
+    # Set openassessment_retry_minutes
+    if oa_block.openassessment_retry_minutes:
+        root.set('openassessment_retry_minutes', str(oa_block.openassessment_retry_minutes))
+
+    # Set openassessment_retry_hours
+    if oa_block.openassessment_retry_hours:
+        root.set('openassessment_retry_hours', str(oa_block.openassessment_retry_hours))
+
     # Set text response
     if oa_block.text_response:
         root.set('text_response', str(oa_block.text_response))
@@ -944,6 +952,22 @@ def parse_from_xml(root):
             leaderboard_show = int(root.attrib['leaderboard_show'])
         except (TypeError, ValueError) as ex:
             raise UpdateFromXmlError('The leaderboard must have an integer value.') from ex
+        
+    # Retrieve the openassessment_retry_minutes if it exists, otherwise set it to 0
+    openassessment_retry_minutes = 0
+    if 'openassessment_retry_minutes' in root.attrib:
+        try:
+            openassessment_retry_minutes = int(root.attrib['openassessment_retry_minutes'])
+        except (TypeError, ValueError) as ex:
+            raise UpdateFromXmlError('The openassessment_retry_minutes must have an integer value.') from ex
+        
+    # Retrieve the openassessment_retry_hours if it exists, otherwise set it to 0
+    openassessment_retry_hours = 0
+    if 'openassessment_retry_hours' in root.attrib:
+        try:
+            openassessment_retry_hours = int(root.attrib['openassessment_retry_hours'])
+        except (TypeError, ValueError) as ex:
+            raise UpdateFromXmlError('The openassessment_retry_hours must have an integer value.') from ex
 
     # Retrieve teams info
     teams_enabled = False
@@ -979,6 +1003,8 @@ def parse_from_xml(root):
         'allow_latex': allow_latex,
         'group_access': group_access,
         'leaderboard_show': leaderboard_show,
+        'openassessment_retry_minutes':openassessment_retry_minutes,
+        'openassessment_retry_hours':openassessment_retry_hours,
         'teams_enabled': teams_enabled,
         'selected_teamset_id': selected_teamset_id,
         'show_rubric_during_response': show_rubric_during_response,


### PR DESCRIPTION
### Description
This PR is created in order to include a new feature that allows student to retry assessment for a configurable time period. 

<p align="center"><img src="https://github.com/eduNEXT/edx-ora2/assets/12719909/5a25421d-289f-47af-8f7f-30866a57da26" width="600"/></p>

### Changes
#### CMS
In this section, I will describe the workflow I went through to add a configuration variable in the ORA edit for the CMS.
<br>
- [x] Added the setting fields openassessment_retry_hours and openassessment_retry_minutes to the template:
     - openassessmentblock/edit/oa_edit_basic_settings_list.html
     
<br>

- [x] Set the following JS files in order to pass those context variables to backend:
     - openassessment/xblock/static/js/src/studio/oa_edit_settings.js
     - openassessment/xblock/static/js/src/studio/oa_edit.js
     - openassessment/xblock/static/js/src/oa_server.js
     
- [x] Set the following *.py backend scripts in order to store the context variables: 
     - openassessment/xblock/utils/schema.py
     - openassessment/xblock/utils/xml.py
     - openassessment/xblock/apis/ora_config_api.py
     - openassessment/xblock/openassessmentblock.py
     - openassessment/xblock/studio_mixin.py
<br>


#### LMS

- [x] Added the optional 'retry' button rendering to the following templates:
    - openassessmentblock/peer/oa_peer_waiting.html
    - openassessmentblock/self/oa_self_assessment.html
    - openassessmentblock/staff/oa_staff_grade.html
    - openassessmentblock/student_training/student_training.html

- [x] Create the function retry_assessment_enable, witch is capable of determinate if the 'retry' button has to be showed to the student:
    - openassessment/xblock/utils/retry_assessment.py
      
<br>

- [x] Imported the retry_assessment_enable function and user_id as a context variable to our templates on the following legacy views in order to send them to their templates:
    - openassessment/xblock/ui_mixins/legacy/staff_assessments/views.py::staff_context()
    - openassessment/xblock/ui_mixins/legacy/self_assessments/views.py::self_context()
    - openassessment/xblock/ui_mixins/legacy/peer_assessments/views.py::peer_context()
    - openassessment/xblock/ui_mixins/legacy/student_training/views.py::training_context()

<br>

- [x] Connect the 'retry' button with the platform function reset_student_attempts()
- ##### .JS
    - openassessment/xblock/static/js/src/lms/oa_peer.js
    - openassessment/xblock/static/js/src/lms/oa_staff.js
    - openassessment/xblock/static/js/src/lms/oa_training.js
    - openassessment/xblock/static/js/src/lms/oa_self.js
    - openassessment/xblock/static/js/src/oa_server.js

- ##### .PY
    - openassessment/xblock/openassessmentblock.py


### Testing

In order to test this feature, you have to go to the CMS site, create an ORA unit and click on edit.
Then go to settings, and set the Assessment Retry Max Time minutes and hours. 

<p align="center"><img src="https://github.com/eduNEXT/edx-ora2/assets/12719909/7d6e5bba-3a30-468d-ba5e-ff9245c0b434" width="700"/></p>

with the time set, you can go to the ORA assessment and verify the 'retry' button render.

<p align="center"><img src="https://github.com/eduNEXT/edx-ora2/assets/12719909/6d473783-2835-4347-b2e3-20f5cf1050d0" width="700"/></p>

After that, you can reset the assessment like this:

<p align="center"><img src="https://github.com/eduNEXT/edx-ora2/assets/12719909/5a25421d-289f-47af-8f7f-30866a57da26" width="500"/></p>

### Test Cases

#### Assessment Retry Max Time 
-  Assessment Retry Max Time mi =0 hours=0 does not render button.
-  Assessment Retry Max Time + submission_time > current_time does render button.
- Assessment Retry Max Time + submission_time < current_time does not render button.

#### ORA Steps
- Self Only: solve the question and reset in the Self step.
- Peer Only: solve the question and reset in Peer waiting screen.
- Staff Only: solve the question and reset in Staff waiting screen.
- Self to Staff: solve the question and reset in Self step, repeat with Staff waiting screen.
- Self to Peer: solve the question and reset in Training step, repeat with Self and Peer waiting screen.