### PR TITLE
fix: avoid display demo button if mfe_url is not configured

### DIFF
--- a/openassessment/templates/openassessmentblock/staff_area/oa_staff_area.html
+++ b/openassessment/templates/openassessmentblock/staff_area/oa_staff_area.html
@@ -17,7 +17,7 @@
             {% else %}
                 <button class="ui-staff__button button-staff-grading" aria-expanded="false" data-panel="openassessment__staff-grading">{% trans "Grade Available Responses" %}</button>
                 {% comment %} Remove if block in AU-617 {% endcomment %}
-                {% if not is_team_assignment %}
+                {% if not is_team_assignment and enhanced_staff_grader_url %}
                     <a href="{{enhanced_staff_grader_url}}" class="ui-staff__button button-enhanced-staff-grader button-enhanced-staff-grader-demo" aria-expanded="false">{% trans "Demo the new Grading Experience" %} <span class="icon fa fa-external-link" aria-hidden="true"></span></a>
                 {% endif %}
             {% endif %}

--- a/openassessment/xblock/staff_area_mixin.py
+++ b/openassessment/xblock/staff_area_mixin.py
@@ -145,10 +145,15 @@ class StaffAreaMixin:
                 context['is_enhanced_staff_grader_enabled'] = False
             else:
                 context['is_enhanced_staff_grader_enabled'] = self.is_enhanced_staff_grader_enabled
-            context['enhanced_staff_grader_url'] = '{esg_url}/{block_id}'.format(
-                esg_url=getattr(settings, 'ORA_GRADING_MICROFRONTEND_URL', ''),
-                block_id=str(self.get_xblock_id())
-            )
+            
+            esg_url = getattr(settings, 'ORA_GRADING_MICROFRONTEND_URL', '')
+            if esg_url:
+                context['enhanced_staff_grader_url'] = '{esg_url}/{block_id}'.format(
+                    esg_url=esg_url,
+                    block_id=str(self.get_xblock_id())
+                )
+            else:
+                context['enhanced_staff_grader_url'] = None
 
             context.update(
                 self.get_staff_assessment_statistics_context(student_item["course_id"], student_item["item_id"])

--- a/openassessment/xblock/static/js/src/lms/oa_course_items_listing.js
+++ b/openassessment/xblock/static/js/src/lms/oa_course_items_listing.js
@@ -70,7 +70,7 @@ export class CourseItemsListingView {
         });
         // Remove this in AU-617
         const teamAssignment = this.model.get('team_assignment');
-        if (hasAssessmentType && !teamAssignment) {
+        if (hasAssessmentType && !teamAssignment && esgRootUrl) {
           this.$el.append(link);
         }
         return this;


### PR DESCRIPTION
This PR allows us to hide the Demo button when the ORA MFE experience is not configured by default and don't want to use the demo feature. 

**How to test**

- You can use this image [palma-20240227-oratest](https://hub.docker.com/layers/ednxops/distro-edunext-edxapp/palma-20240227-oratest/images/sha256-66f388ad76cda0648ada15379d93ede0e42e385a38c0671480a1070932e1b9ac?context=repo)
-  Remove the `ORA_GRADING_MICROFRONTEND_URL` inside lms settings (if you are testing dev mode set the variable to `None` or `''`).

-  Create or add to a course an Open Response with Staff Grading, publish the changes, and go to the LMS.

_With the URL configured:_
![image](https://github.com/eduNEXT/edx-ora2/assets/66016493/b11f4854-96be-4df8-87d9-df8ee3d46c77)


_Without the URL:_

![image](https://github.com/eduNEXT/edx-ora2/assets/66016493/264e1450-1f8c-4145-a1a8-4462139d5877)


[IRA](https://edunext.atlassian.net/browse/DS-808)
